### PR TITLE
Fix baseline script

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ The other classifiers available are:
 - `GPT3Classifier`: the one used for the GPT-3 baseline in the paper
 - `TransformersCausalLMClassifier`: takes as input a `model_type` string, and runs an arbitrary CausalLM from the [HuggingFace Model Hub](https://huggingface.co/models?pipeline_tag=text-generation&sort=downloads)
 
+For example, to generate predictions from DistilGPT-2 on the first 10 examples of the ADE Corpus you can run:
+
+```buildoutcfg
+python -m raft_baselines.scripts.raft_predict with n_test=10 'configs=["ade_corpus_v2"]' classifier_name=TransformersCausalLMClassifier 'classifier_kwargs={"model_type":"gpt2"}'
+```
+
 In order to run experiments with GPT-3, you will need to have an OpenAI API key. Create a file called `.env` and put your API key there. Copy the format of `.env-example`:
 
 ```buildoutcfg

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The other classifiers available are:
 For example, to generate predictions from DistilGPT-2 on the first 10 examples of the ADE Corpus you can run:
 
 ```buildoutcfg
-python -m raft_baselines.scripts.raft_predict with n_test=10 'configs=["ade_corpus_v2"]' classifier_name=TransformersCausalLMClassifier 'classifier_kwargs={"model_type":"gpt2"}'
+python -m raft_baselines.scripts.raft_predict with n_test=10 'configs=["ade_corpus_v2"]' classifier_name=TransformersCausalLMClassifier 'classifier_kwargs={"model_type":"distilgpt2"}'
 ```
 
 In order to run experiments with GPT-3, you will need to have an OpenAI API key. Create a file called `.env` and put your API key there. Copy the format of `.env-example`:

--- a/src/raft_baselines/classifiers/random_classifier.py
+++ b/src/raft_baselines/classifiers/random_classifier.py
@@ -1,5 +1,5 @@
 import random
-from typing import Mapping
+from typing import Mapping, Optional
 
 import datasets
 
@@ -13,7 +13,7 @@ class RandomClassifier(Classifier):
         super().__init__(training_data)
         random.seed(seed)
 
-    def classify(self, target: Mapping[str, str]) -> Mapping[str, float]:
+    def classify(self, target: Mapping[str, str], random_seed: Optional[int] = None) -> Mapping[str, float]:
         result = {c: 0.0 for c in self.classes}
         result[random.choice(self.classes)] = 1.0
 

--- a/src/raft_baselines/scripts/raft_predict.py
+++ b/src/raft_baselines/scripts/raft_predict.py
@@ -40,7 +40,7 @@ def base_config():
     classifier_name = "GPT3Classifier"
     classifier_kwargs = {
         # change to davinci to replicate results from the paper
-        "engine": "ada",
+        # "engine": "ada",
     }
     configs = datasets.get_dataset_config_names("ought/raft")
     # set n_test to -1 to run on all test examples
@@ -83,6 +83,8 @@ def make_predictions(
     random_seed,
 ):
     classifier = classifier_cls(train_dataset, **classifier_kwargs, **extra_kwargs)
+    print(f"MODEL TYPE: {classifier.tokenizer.tokenizer.name_or_path}")
+
 
     if n_test > -1:
         test_dataset = test_dataset.select(range(n_test))

--- a/src/raft_baselines/scripts/raft_predict.py
+++ b/src/raft_baselines/scripts/raft_predict.py
@@ -83,8 +83,6 @@ def make_predictions(
     random_seed,
 ):
     classifier = classifier_cls(train_dataset, **classifier_kwargs, **extra_kwargs)
-    print(f"MODEL TYPE: {classifier.tokenizer.tokenizer.name_or_path}")
-
 
     if n_test > -1:
         test_dataset = test_dataset.select(range(n_test))


### PR DESCRIPTION
This PR fixes a minor bug where the `RandomClassifier.classify` was provided a `random_seed` argument that didn't exist in the function signature.

I also took the liberty to tweak the README