### PR TITLE
fix typo in neurips_impact_statement_risks

### DIFF
--- a/src/raft_baselines/scripts/test_naive_bayes.py
+++ b/src/raft_baselines/scripts/test_naive_bayes.py
@@ -3,7 +3,7 @@ import datasets
 from raft_baselines.classifiers import NaiveBayesClassifier
 
 train = datasets.load_dataset(
-    "ought/raft", "neruips_impact_statement_risks", split="train"
+    "ought/raft", "neurips_impact_statement_risks", split="train"
 )
 
 classifier = NaiveBayesClassifier(train)


### PR DESCRIPTION
Fix a small typo in [test_naive_bayes.py](https://github.com/oughtinc/raft-baselines/compare/master...wiesenthal:typo-fix?expand=1#diff-996431096f1d792a612a13a01074c7a4c6e30d384a6f3b2a547f4c81fe357aea)