### PR TITLE
Update openai calls because previous ones had been deprecated

### DIFF
--- a/src/raft_baselines/utils/gpt3_utils.py
+++ b/src/raft_baselines/utils/gpt3_utils.py
@@ -1,20 +1,14 @@
 import openai
-from dotenv import load_dotenv
-import os
 import time
 from cachetools import cached, LRUCache
-from typing import List, Dict, Tuple, Any, cast
-
-from raft_baselines.utils.tokenizers import TransformersTokenizer
-
-load_dotenv()
-OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+from typing import Dict, Tuple, Any, cast
+import tiktoken
 
 
 @cached(cache=LRUCache(maxsize=1e9))
 def complete(
     prompt: str,
-    engine: str = "ada",
+    model: str = "ada",
     max_tokens: int = 5,
     temperature: float = 1.0,
     top_p: float = 1.0,
@@ -25,8 +19,7 @@ def complete(
     frequency_penalty: float = 0.0,
 ):
     openai_completion_args = dict(
-        api_key=OPENAI_API_KEY,
-        engine=engine,
+        model=model,
         prompt=prompt,
         max_tokens=max_tokens,
         temperature=temperature,
@@ -43,7 +36,7 @@ def complete(
     retries = 0
     while not success:
         try:
-            response = openai.Completion.create(**openai_completion_args)
+            response = openai.completions.create(**openai_completion_args)
             success = True
         except Exception as e:
             print(f"Exception in OpenAI completion: {e}")
@@ -56,40 +49,3 @@ def complete(
                 time.sleep(retries * 15)
 
     return cast(Dict[str, Any], response)
-
-
-@cached(cache=LRUCache(maxsize=1e9))
-def search(
-    documents: Tuple[str, ...], query: str, engine: str = "ada"
-) -> List[Dict[str, Any]]:
-    response = None
-    error = None
-    tokenizer = TransformersTokenizer("gpt2")
-    query = tokenizer.truncate_by_tokens(query, 1000)
-    short_enough_documents = [
-        tokenizer.truncate_by_tokens(document, 2034 - tokenizer.num_tokens(query))
-        for document in documents
-    ]
-
-    success = False
-    retries = 0
-    while not success:
-        try:
-            response = openai.Engine(engine, api_key=OPENAI_API_KEY).search(
-                documents=short_enough_documents, query=query
-            )
-            success = True
-        except Exception as e:
-            print(f"Exception in OpenAI search: {e}")
-            retries += 1
-            if retries > 3:
-                raise Exception("Max retries reached")
-                break
-            else:
-                print("retrying")
-                time.sleep(retries * 15)
-
-    assert response is not None
-    results = response["data"]
-
-    return results


### PR DESCRIPTION
GPT-3 implementation was not running due to outdated api calls, so updated completion call.

Refactored the semantic search to use embeddings because Engine.search api was deprecated. 
This allowed me to make the *semantically_select_training_examples* method in *GPT3Classifier* identical to that in *TransformersCausalLMClassifier*, so this method could be moved up to base class *InContextClassifier*. I'll leave this decision up to repo owners.

Tested *GPT3Classifier* and *OpenAIEmbedder* and they work now.

NOTE: openai will automatically use OPENAI_API_KEY environment variable.